### PR TITLE
Fix #! shebang

### DIFF
--- a/bin/otv
+++ b/bin/otv
@@ -1,3 +1,3 @@
-#!env python3
+#!/usr/bin/env python3
 from otv import otv
 otv.main()


### PR DESCRIPTION
This uses the full path for `env` as required.

Fixes #13