### PR TITLE
Fix path names for case-sensitive file systems

### DIFF
--- a/bin/otv
+++ b/bin/otv
@@ -1,3 +1,3 @@
-#!env python3
+#!/usr/bin/env python3
 from otv import otv
 otv.main()

--- a/otv/ortho.py
+++ b/otv/ortho.py
@@ -45,7 +45,7 @@ class Tile:
         return True
 
     def validate_earth_nav_data(self):
-        if not self.validate_dir("earth nav data"):
+        if not self.validate_dir("Earth nav data"):
             return False
 
         return True


### PR DESCRIPTION
Use directory name "Earth nav data" which is how Ortho4XP creates directories and X-Plane expects them.
    
This has not been seen as a problem in Windows because Windows is case-insensitive.
    
The problem was reproducible on Linux, though.
    
Fixes #11


Thank you so much for this tile-checker @dyoung522!